### PR TITLE
Add Netlify support

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -3,6 +3,7 @@ import os
 import uuid
 import subprocess
 from flask import Flask, request, redirect, url_for, send_from_directory, render_template, flash
+import awsgi
 
 # ─── Paths ──────────────────────────────────────────────────────────────────────
 BASE_DIR      = os.path.dirname(os.path.abspath(__file__))
@@ -68,4 +69,9 @@ def upload_file():
 @app.route('/download/<filename>')
 def download_file(filename):
     return send_from_directory(OUTPUT_FOLDER, filename, as_attachment=True)
+
+
+def handler(event, context):
+    """AWS Lambda handler entrypoint."""
+    return awsgi.response(app, event, context)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "pip install -r requirements.txt"
+  functions = "api"
+
+[[redirects]]
+  from = "/*"
+  to = "/.netlify/functions/index"
+  status = 200

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pretty_midi
 numpy
 soundfile
 gunicorn
+awsgi


### PR DESCRIPTION
## Summary
- add a Netlify configuration file that builds requirements and redirects traffic
- add `handler()` for AWS Lambda via awsgi and import awsgi
- add awsgi dependency

## Testing
- `python3 -m py_compile api/index.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6874aef925e883218b40004f2f7e12d3