### PR TITLE
Improve README for local run & Netlify deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-hello
+# MP3 to MIDI Converter
+
+This project provides a small Flask application that converts uploaded MP3 files to MIDI using the [transkun](https://pypi.org/project/transkun/) CLI.
+
+## Running locally
+
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the Flask development server
+   ```bash
+   FLASK_APP=api/index.py flask run
+   ```
+   The app will be available at [http://localhost:5000](http://localhost:5000).
+
+## Deploying to Netlify
+
+The repository includes a `netlify.toml` configuration for deploying the Flask app as a serverless function. When setting up your Netlify site, use the following values:
+
+- **Build command:** `pip install -r requirements.txt`
+- **Functions directory:** `api`
+
+Netlify will build the Python dependencies and deploy the `api/index.py` function. All incoming requests are redirected to this function according to `netlify.toml`.
+


### PR DESCRIPTION
## Summary
- document local Flask run
- add Netlify deployment info pulled from `netlify.toml`

## Testing
- `python -m py_compile api/index.py`


------
https://chatgpt.com/codex/tasks/task_e_6874b700e99083218c72a600330e10c2