### PR TITLE
Fix Gunicorn binding for Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn api.index:app --timeout 300
+web: gunicorn -b 0.0.0.0:$PORT api.index:app --timeout 300
 


### PR DESCRIPTION
## Summary
- ensure Gunicorn binds to the port provided by platform

## Testing
- `gunicorn -b 0.0.0.0:8000 api.index:app --timeout 300`

------
https://chatgpt.com/codex/tasks/task_e_6874ca8f0014832180a68f042c28f82b