### PR TITLE
Fix Netlify build port usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project provides a small Flask application that converts uploaded MP3 files
 
 The repository includes a `netlify.toml` configuration for deploying the Flask app as a serverless function. When setting up your Netlify site, use the following values:
 
-- **Build command:** `pip install -r requirements.txt`
+- **Build command:** `pip install -r requirements.txt && cp -r templates api/ && FLASK_APP=api/index.py flask run --host=0.0.0.0 --port=${PORT:-8888}`
 - **Functions directory:** `api`
 
 Netlify will build the Python dependencies and deploy the `api/index.py` function. All incoming requests are redirected to this function according to `netlify.toml`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,7 @@
 [build]
-  command = "pip install -r requirements.txt && cp -r templates api/"
+  # Install dependencies, copy HTML templates, and start the Flask server.
+  # Use a default port of 8888 if $PORT isn't provided by the environment.
+  command = "pip install -r requirements.txt && cp -r templates api/ && FLASK_APP=api/index.py flask run --host=0.0.0.0 --port=${PORT:-8888}"
   functions = "api"
 
 [[redirects]]


### PR DESCRIPTION
## Summary
- ensure Netlify's build command starts Flask with a default port
- document the updated Netlify build command

## Testing
- `python -m py_compile api/index.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6874f17920d48321a66f3330f4e244e3